### PR TITLE
Finished Lab3B and thereby Lab3

### DIFF
--- a/src/kvraft/client.go
+++ b/src/kvraft/client.go
@@ -148,7 +148,7 @@ func (ck *Clerk) Operation(args *OperationArgs) string {
 }
 
 func (ck *Clerk) logClerk(fatal bool, format string, args ...interface{}) {
-	if !Debug {
+	if !KVDebug {
 		return
 	}
 	prefix := "Clerk-" + ck.base64IdPrefix + ": "
@@ -160,7 +160,7 @@ func (ck *Clerk) logClerk(fatal bool, format string, args ...interface{}) {
 	}
 }
 func (ck *Clerk) logRPC(fatal bool, seqNum int, serverId int, format string, args ...interface{}) {
-	if !Debug {
+	if !KVDebug {
 		return
 	}
 	prefixClerk := "Clerk-" + ck.base64IdPrefix + " "

--- a/src/kvraft/client.go
+++ b/src/kvraft/client.go
@@ -18,6 +18,7 @@ type Clerk struct {
 	nextSeqNum      int32 // atomically increase for SeqNum
 }
 
+// generate random int64
 func nrand() int64 {
 	max := big.NewInt(int64(1) << 62)
 	bigx, _ := rand.Int(rand.Reader, max)

--- a/src/kvraft/common.go
+++ b/src/kvraft/common.go
@@ -16,6 +16,8 @@ const (
 	ErrLogEntryErased     = "ErrLogEntryErased"     // previous index is detected with a new log entry, definitely not applied
 	ErrTermChanged        = "ErrTermChanged"        // Periodic term detector found that the term of the previous leader has changed, no guarantee if the command will be applied or erased.
 )
+
+// used to shorten the uid of a client for logging
 const PrefixLength = 5
 
 type OperationType int

--- a/src/kvraft/common.go
+++ b/src/kvraft/common.go
@@ -7,7 +7,7 @@ import (
 )
 
 // used to control whether or not print debugging info
-const KVDebug = true
+const KVDebug = false
 const (
 	OK                    = "OK"                    // applied
 	ErrNoKey              = "ErrNoKey"              // for GET, applied but no key

--- a/src/kvraft/common.go
+++ b/src/kvraft/common.go
@@ -7,7 +7,7 @@ import (
 )
 
 // used to control whether or not print debugging info
-const Debug = true
+const KVDebug = true
 const (
 	OK                    = "OK"                    // applied
 	ErrNoKey              = "ErrNoKey"              // for GET, applied but no key

--- a/src/kvraft/dstest.py
+++ b/src/kvraft/dstest.py
@@ -1,0 +1,1 @@
+../raft/dstest.py

--- a/src/raft/raft.go
+++ b/src/raft/raft.go
@@ -180,6 +180,11 @@ func (rf *Raft) IsStateSizeAbove(threshold int) bool {
 	return rf.persister.RaftStateSize() >= threshold
 }
 
+// api for the service to read snapshot from disk
+func (rf *Raft) ReadSnapshot() []byte {
+	return rf.persister.ReadSnapshot()
+}
+
 // restore previously persisted Raft state. Used only when the server restarts (from crash) along with read snapshot
 func (rf *Raft) readPersist(data []byte) {
 	if data == nil || len(data) < 1 { // bootstrap without any state
@@ -283,7 +288,6 @@ type RequestVoteArgs struct {
 
 // RequestVote RPC reply structure.
 type RequestVoteReply struct {
-	// Your Data here (2A).
 	Term         int
 	VotedGranted bool
 }
@@ -431,7 +435,6 @@ func (rf *Raft) HandleAppendEntries(args *AppendEntriesArgs, reply *AppendEntrie
 
 // RequestVote RPC handler.
 func (rf *Raft) HandleRequestVote(args *RequestVoteArgs, reply *RequestVoteReply) {
-	// Your code here (2A, 2B).
 	rf.mu.Lock()
 	rf.logProducer(args.CandidateId,
 		"Received RequestVote in candidate term %d",

--- a/src/raft/raft.go
+++ b/src/raft/raft.go
@@ -74,10 +74,10 @@ func (identity ServerIdentity) String() string {
 }
 
 const (
-	MIN_ELECTION_TIMEOUT_MILLIS  int64 = 500
-	MAX_ELECTION_TIMEOUT_MILLIS  int64 = 1000
-	APPEND_ENTRIES_PERIOD_MILLIS int64 = 100
-	TICKER_PERIOD_MILLIS         int64 = 30
+	MinElectionTimeoutMillis  int64 = 500
+	MaxElectionTimeoutMillis  int64 = 1000
+	AppendEntriesPeriodMillis int64 = 100
+	TickerPeriodMillis        int64 = 30
 )
 
 // A Go object implementing a single Raft peer.
@@ -715,7 +715,7 @@ func (rf *Raft) ticker() {
 			rf.runForCandidate()
 		}
 		rf.mu.Unlock()
-		time.Sleep(time.Duration(TICKER_PERIOD_MILLIS) * time.Millisecond)
+		time.Sleep(time.Duration(TickerPeriodMillis) * time.Millisecond)
 	}
 }
 
@@ -727,7 +727,7 @@ func (rf *Raft) commitObserver() {
 	go func() {
 		rf.logServer("The timer to send notifications for applying command started!")
 		for !rf.killed() {
-			time.Sleep(time.Duration(TICKER_PERIOD_MILLIS) * time.Millisecond)
+			time.Sleep(time.Duration(TickerPeriodMillis) * time.Millisecond)
 			// wrapped in lock to reduce the number of missed notifications
 			rf.mu.Lock()
 			rf.commitCond.Broadcast()
@@ -790,7 +790,7 @@ func (rf *Raft) broadcastAppendEntries(isHeartbeat bool) {
 
 	// must update the next broadcast time if it is heartbeat
 	if isHeartbeat {
-		rf.nextHeartbeatTime = time.Now().Add(time.Duration(APPEND_ENTRIES_PERIOD_MILLIS) * time.Millisecond)
+		rf.nextHeartbeatTime = time.Now().Add(time.Duration(AppendEntriesPeriodMillis) * time.Millisecond)
 	}
 
 	rf.logServer("BroadCast AppendEntries Messages...")
@@ -1130,8 +1130,8 @@ func (rf *Raft) logConsumer(producerId int, format string, args ...interface{}) 
 	log.Printf(message, args...)
 }
 func generateRandomTimeout() time.Duration {
-	return time.Duration(rand.Int63n(MAX_ELECTION_TIMEOUT_MILLIS-MIN_ELECTION_TIMEOUT_MILLIS)+
-		MIN_ELECTION_TIMEOUT_MILLIS) * time.Millisecond
+	return time.Duration(rand.Int63n(MaxElectionTimeoutMillis-MinElectionTimeoutMillis)+
+		MinElectionTimeoutMillis) * time.Millisecond
 }
 
 // Given the index of a log entry, get that entry (copy). Fail-fast is used for manifesting errors as early as possible


### PR DESCRIPTION
Because the design of Lab3A took longer time, the lab3B can be quickly finished. 
Lab3A requires some detailed thoughs on using what kind of synchronization primitives. 
The speed of debug benefits significantly from the detailed logging to check invariants constantly. 
In debugging, fail-fast options like Log.Fatalf proves to be very useful, although not suitable for deployment, to shrink the fault interval and prevent faults from being masked. Also, abtracting out logging functions to create common patterns also turned out to be a useful way to printing common information and classify logs into different sections.